### PR TITLE
Add Dockerfile for Streamlit app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.9-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY app/ app/
+
+# Expose Streamlit port
+EXPOSE 8501
+
+# Run Streamlit when container launches
+ENTRYPOINT ["streamlit", "run", "app/main.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ FPL managers must make weekly choices (transfers, captaincy, bench order) with u
    * Creating a virtual environment
    * Running `pip install -r requirements.txt`
 
+## Docker
+Build the image:
+
+```bash
+docker build -t fpl-app .
+```
+
+Run the container:
+
+```bash
+docker run -p 8501:8501 fpl-app
+```
+
 ## 🛠 Methods
 
 ### Baseline

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("Fantasy Football Points Prediction")
+st.write("Streamlit app placeholder.")


### PR DESCRIPTION
## Summary
- Create Dockerfile based on `python:3.9-slim` that installs requirements, copies the `app/` code, exposes port `8501` and runs the Streamlit entrypoint.
- Provide a minimal `app/main.py` placeholder Streamlit script.
- Document Docker build and run commands in the README.

## Testing
- `pytest -q`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689386ddad048329bbcd2a4c422c1ded