### PR TITLE
Separate optional ML frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ FPL managers must make weekly choices (transfers, captaincy, bench order) with u
 ## Setup
    * Creating a virtual environment
    * Running `pip install -r requirements.txt`
+   * *(Optional)* For LSTM or other neural network models, install extra frameworks with `pip install -r requirements-optional-ml.txt`
 
 ## 🛠 Methods
 
@@ -54,7 +55,7 @@ FPL managers must make weekly choices (transfers, captaincy, bench order) with u
 - Uses full feature set without aggregation
 
 ### Optional: Time-Series Modeling
-- LSTM 
+- LSTM (requires TensorFlow or PyTorch from `requirements-optional-ml.txt`)
 
 ---
 

--- a/requirements-optional-ml.txt
+++ b/requirements-optional-ml.txt
@@ -1,0 +1,4 @@
+# Optional deep learning frameworks for neural network models (e.g., LSTM)
+tensorflow>=2.12
+torch>=2.0
+torchvision>=0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,7 @@ numpy>=1.23
 scikit-learn>=1.2
 xgboost>=1.7
 lightgbm>=3.3
-tensorflow>=2.12  # for optional LSTM, replace with torch if using PyTorch
-# torch>=2.0
-# torchvision>=0.15
+# Optional deep learning frameworks are listed in requirements-optional-ml.txt
 
 # Visualization
 matplotlib>=3.6


### PR DESCRIPTION
## Summary
- remove deep learning frameworks from core requirements and move them to an optional requirements file
- document that LSTM or neural network models require TensorFlow or PyTorch

## Testing
- `pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_689386c657908329b90ce07e4c2b43ea